### PR TITLE
Fixes in OEP/CPF Downloaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If the ephemeris release center is not provided, the CPF ephemeris files are dow
 ```python
 >>> from slrfield import cpf_download
 >>> cpf_dir_cddis,cpf_files_cddis = cpf_download() # From CDDIS by default;
->>> print(cpf_dir,cpf_files)
+>>> print(cpf_dir_cddis,cpf_files_cddis)
 ```
 
 A directory where CPF files are stored, such as *CPF/CDDIS/2020-10-02/*, will be automatically created.

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'astropy>=4.3.1',
         'tqdm',
         'colorama',
-        'beautifulsoup4'
+        'beautifulsoup4',
+        'requests'
         ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup,find_packages 
+from setuptools import setup, find_packages
 
 setup(
     name='slrfield',
@@ -10,8 +10,8 @@ setup(
     license='MIT',
     long_description_content_type='text/markdown',
     long_description=open('README.md', 'rb').read().decode('utf-8'),
-    keywords = ['SLR','CPF'],
-    python_requires = '>=3.8',
+    keywords=['SLR', 'CPF'],
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Education',
@@ -20,7 +20,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: MIT License',
         ],
-    packages = find_packages(),
+    packages=find_packages(),
     include_package_data=True,
     install_requires=[
         'scipy',

--- a/slrfield/cpf/cpf_download.py
+++ b/slrfield/cpf/cpf_download.py
@@ -340,10 +340,8 @@ def get_cpf_filelist(server,dir_cpf_from,mode):
 
     # extract time infomation
     time_info = soup.find_all('span')
-    if mode == 'bycurrent':
-        time_list = [ele.get_text().split('  ')[0] for ele in time_info][2:] # Remove two extra items
-    elif mode == 'bydate':
-        time_list = [ele.get_text().split('  ')[0] for ele in time_info]    
+    time_list = [ele.get_text().split('  ')[0] for ele in time_info][2:] # Remove MD5SUMS and SHA512SUMS files
+
     n_time_list = len(time_list)
 
     # extract filename infomation

--- a/slrfield/cpf/cpf_download.py
+++ b/slrfield/cpf/cpf_download.py
@@ -47,7 +47,7 @@ def download_bycurrent(source,satnames=None,keep=True):
            
     elif source == 'EDC':
         server = 'edc.dgfi.tum.de'
-        dir_cpf_from = '~/slr/cpf_predicts//current/'
+        dir_cpf_from = '~/slr/cpf_predicts_v2/current/'
         ftp = FTP(server,timeout=200)
         ftp.login()
         ftp.cwd(dir_cpf_from)
@@ -125,7 +125,7 @@ def download_bydate(source,date,satnames,keep=True):
         for satname in reduplicates:
             cpf_files_list_reduced = []
             find_flag = False
-            dir_cpf_from = '/archive/slr/cpf_predicts/' + date_dir + '/' + satname + '/'
+            dir_cpf_from = '/archive/slr/cpf_predicts_v2/' + date_dir + '/' + satname + '/'
             dirs_cpf_from.append(dir_cpf_from)
             cpf_files_dict,cpf_files_list = get_cpf_filelist(server,dir_cpf_from,'bydate') 
 
@@ -149,7 +149,7 @@ def download_bydate(source,date,satnames,keep=True):
             if not find_flag and date_str2[:2]>='05':  
                 cpf_files_list_reduced = []
                 dirs_cpf_from.remove(dir_cpf_from)
-                dir_cpf_from = '/archive/slr/cpf_predicts/' + '20'+date_str2[:2] + '/' + satname + '/'
+                dir_cpf_from = '/archive/slr/cpf_predicts_v2/' + '20'+date_str2[:2] + '/' + satname + '/'
                 dirs_cpf_from.append(dir_cpf_from)
                 cpf_files_dict,cpf_files_list = get_cpf_filelist(server,dir_cpf_from,'bydate')
     
@@ -176,7 +176,7 @@ def download_bydate(source,date,satnames,keep=True):
         for satname in reduplicates:
             cpf_files_list_reduced = []
             find_flag = False
-            dir_cpf_from = '~/slr/cpf_predicts//' + date_dir + '/' + satname + '/'
+            dir_cpf_from = '~/slr/cpf_predicts_v2//' + date_dir + '/' + satname + '/'
             dirs_cpf_from.append(dir_cpf_from)
             ftp.cwd(dir_cpf_from)
             cpf_files_list = ftp.nlst('-t','*cpf*') # list files containing 'cpf' from newest to oldest  
@@ -197,7 +197,7 @@ def download_bydate(source,date,satnames,keep=True):
             if not find_flag and date_str2[:2]>='05':  
                 cpf_files_list_reduced = []
                 dirs_cpf_from.remove(dir_cpf_from)
-                dir_cpf_from = '~/slr/cpf_predicts//' + '20'+date_str2[:2] + '/' + satname + '/'
+                dir_cpf_from = '~/slr/cpf_predicts_v2//' + '20'+date_str2[:2] + '/' + satname + '/'
                 dirs_cpf_from.append(dir_cpf_from)
                 ftp.cwd(dir_cpf_from)
                 cpf_files_list = ftp.nlst('-t','*cpf*') # list files containing 'cpf' from newest to oldest 

--- a/slrfield/cpf/cpf_download.py
+++ b/slrfield/cpf/cpf_download.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from ftplib import FTP
 import requests
 from bs4 import BeautifulSoup
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
+from astropy.units import day
 from warnings import warn
 
 from ..utils.try_download import tqdm_ftp, tqdm_request_http
@@ -106,11 +107,11 @@ def download_bydate(source,date,satnames,keep=True):
         reduplicates = satnames
     else:
         raise Exception('Type of satname should be str or list.')     
-    
+
     dirs_cpf_from,cpf_files = [],[]
     date_dir = date[:4]
     date_str1  = Time(date).strftime('%y%m%d')
-    date_str2  = (Time(date)-7).strftime('%y%m%d') # ephemeris updates for some high-orbit satellites may take several days
+    date_str2  = (Time(date)-7*day).strftime('%y%m%d') # ephemeris updates for some high-orbit satellites may take several days
     date_str = Time(date).strftime('%Y%m%d%H%M%S')
     dir_cpf_to = 'CPF/'+source+'/'+ date[:10] + '/'
     

--- a/slrfield/cpf/cpf_download.py
+++ b/slrfield/cpf/cpf_download.py
@@ -123,10 +123,15 @@ def download_bydate(source,date,satnames,keep=True):
     if source == 'CDDIS':
         server = 'https://cddis.nasa.gov'   
 
+        if Time(date) < Time('2021-10-01'):
+            base_url = '/archive/slr/cpf_predicts/'
+        else:
+            base_url = '/archive/slr/cpf_predicts_v2/'
+
         for satname in reduplicates:
             cpf_files_list_reduced = []
             find_flag = False
-            dir_cpf_from = '/archive/slr/cpf_predicts_v2/' + date_dir + '/' + satname + '/'
+            dir_cpf_from = base_url + date_dir + '/' + satname + '/'
             dirs_cpf_from.append(dir_cpf_from)
             cpf_files_dict,cpf_files_list = get_cpf_filelist(server,dir_cpf_from,'bydate') 
 
@@ -339,9 +344,18 @@ def get_cpf_filelist(server,dir_cpf_from,mode):
     res = requests.get(server + dir_cpf_from)
     soup = BeautifulSoup(res.text, 'html.parser')
 
+    # Remove MD5SUMS and SHA512SUMS files manually
+    # Done this way as not every directory has the checksum files present
+    item_to_delete = soup.find(id="MD5SUMS")
+    if item_to_delete:
+        item_to_delete.parent.decompose()
+    item_to_delete = soup.find(id="SHA512SUMS")
+    if item_to_delete:
+        item_to_delete.parent.decompose()
+
     # extract time infomation
     time_info = soup.find_all('span')
-    time_list = [ele.get_text().split('  ')[0] for ele in time_info][2:] # Remove MD5SUMS and SHA512SUMS files
+    time_list = [ele.get_text().split('  ')[0] for ele in time_info]
 
     n_time_list = len(time_list)
 

--- a/slrfield/cpf/cpf_download.py
+++ b/slrfield/cpf/cpf_download.py
@@ -176,13 +176,19 @@ def download_bydate(source,date,satnames,keep=True):
 
     elif source == 'EDC':
         server = 'edc.dgfi.tum.de'    
+
+        if Time(date) < Time('2021-10-01'):
+            base_url = '~/slr/cpf_predicts/'
+        else:
+            base_url = '~/slr/cpf_predicts_v2/'
+
         ftp = FTP(server,timeout=200)    
         ftp.login()    
 
         for satname in reduplicates:
             cpf_files_list_reduced = []
             find_flag = False
-            dir_cpf_from = '~/slr/cpf_predicts_v2//' + date_dir + '/' + satname + '/'
+            dir_cpf_from = base_url + date_dir + '/' + satname + '/'
             dirs_cpf_from.append(dir_cpf_from)
             ftp.cwd(dir_cpf_from)
             cpf_files_list = ftp.nlst('-t','*cpf*') # list files containing 'cpf' from newest to oldest  

--- a/slrfield/cpf/cpf_download.py
+++ b/slrfield/cpf/cpf_download.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 from astropy.time import Time
 from warnings import warn
 
-from ..utils.try_download import tqdm_ftp,tqdm_request_cpf
+from ..utils.try_download import tqdm_ftp, tqdm_request_http
 
 def download_bycurrent(source,satnames=None,keep=True):
     """
@@ -42,7 +42,7 @@ def download_bycurrent(source,satnames=None,keep=True):
         
     if source == 'CDDIS':
         server = 'https://cddis.nasa.gov'
-        dir_cpf_from = '/archive/slr/cpf_predicts/current/' 
+        dir_cpf_from = '/archive/slr/cpf_predicts_v2/current/' 
         cpf_files_dict,cpf_files_list = get_cpf_filelist(server,dir_cpf_from,'bycurrent')
            
     elif source == 'EDC':
@@ -262,7 +262,7 @@ def cpf_download_prior(satnames = None,date = None,source = 'CDDIS',keep=True):
             for cpf_file in cpf_files:
                 url = server+dir_cpf_from+cpf_file
                 desc = 'Downloading {:s}'.format(cpf_file)
-                missing_cpf_file = tqdm_request_cpf(url,dir_cpf_to,cpf_file,desc)
+                missing_cpf_file = tqdm_request_http(url,dir_cpf_to,cpf_file,desc)
                 if missing_cpf_file is not None: missing_cpf_files.append(missing_cpf_file)
                 
         if source == 'EDC':
@@ -284,7 +284,7 @@ def cpf_download_prior(satnames = None,date = None,source = 'CDDIS',keep=True):
             for dir_cpf_from,cpf_file in zip(dirs_cpf_from,cpf_files):
                 url = server+dir_cpf_from+cpf_file
                 desc = 'Downloading {:s}'.format(cpf_file)
-                missing_cpf_file = tqdm_request_cpf(url,dir_cpf_to,cpf_file,desc)
+                missing_cpf_file = tqdm_request_http(url,dir_cpf_to,cpf_file,desc)
                 if missing_cpf_file is not None: missing_cpf_files.append(missing_cpf_file)
 
         if source == 'EDC': 

--- a/slrfield/utils/data_download.py
+++ b/slrfield/utils/data_download.py
@@ -45,7 +45,7 @@ def download_eop(out_days=7, dir_to=None):
     else:
         desc = "Downloading the latest EOP '{:s}' from IERS".format(file)
 
-    if tqdm_request_http(url, dir_to, file, desc) is None:
+    if tqdm_request_http(url, dir_to, file, desc) is not None:
         print('SLRfield was unable to import Earth Orientation Parameters '
               + '(EOP) data. It is recommended to try again or to manually'
               + 'download this data (finals.all.iau2000.txt) and place it '

--- a/slrfield/utils/data_download.py
+++ b/slrfield/utils/data_download.py
@@ -2,9 +2,10 @@
 from datetime import datetime,timedelta
 from os import path,makedirs,remove
 from pathlib import Path
-from ftplib import FTP
+import requests
 
-from .try_download import tqdm_ftp
+from .try_download import tqdm_request_http
+
 
 def download_eop(out_days=7,dir_to=None):
     """
@@ -24,25 +25,29 @@ def download_eop(out_days=7,dir_to=None):
         home = str(Path.home())
         dir_to = home + '/src/eop-data/'
     
-    file = 'finals2000A.all'
+    file = 'finals.all.iau2000.txt'
     dir_file = dir_to + file
 
-    server = 'ftp.iers.org'
-    src_dir = '~/products/eop/rapid/standard/'
+    url = 'https://datacenter.iers.org/data/latestVersion/finals.all.iau2000.txt'
 
     if not path.exists(dir_to): makedirs(dir_to)
-    if not path.exists(dir_file):
-        ftp_access(server,src_dir)
-        desc = "Downloading the latest EOP '{:s}' from IERS".format(file)
-        tqdm_ftp(ftp,dir_to,file,desc)
-    else:
+
+    if path.exists(dir_file):
+        # First check if the file needs updating
         modified_time = datetime.fromtimestamp(path.getmtime(dir_file))
         if datetime.now() > modified_time + timedelta(days=out_days):
             remove(dir_file)
-            ftp_access(server,src_dir)
             desc = "Updating EOP '{:s}' from IERS".format(file)
-            tqdm_ftp(ftp,dir_to,file,desc)
         else:
             print("EOP '{0:s}' in {1:s} is already the latest.".format(file,dir_to)) 
+            return dir_file
+    else:
+        desc = "Downloading the latest EOP '{:s}' from IERS".format(file)
+        
+    if tqdm_request_http(url,dir_to,file,desc) is None:
+        print('SLRfield was unable to import Earth Orientation Parameters (EOP) data. ' \
+            + 'It is recommended to try again or to manually download this data (finals.all.iau2000.txt)'\
+            + f' and place it in {dir_to}.')
+        raise ImportError('Unable to download EOP data')
 
-    return dir_file  
+    return dir_file

--- a/slrfield/utils/data_download.py
+++ b/slrfield/utils/data_download.py
@@ -1,36 +1,36 @@
 
-from datetime import datetime,timedelta
-from os import path,makedirs,remove
+from datetime import datetime, timedelta
+from os import path, makedirs, remove
 from pathlib import Path
-import requests
 
 from .try_download import tqdm_request_http
 
 
-def download_eop(out_days=7,dir_to=None):
+def download_eop(out_days=7, dir_to=None):
     """
     Download or update the Earth Orientation Parameters(EOP) file from IERS
 
-    Usage: 
+    Usage:
         >>> eop_file = download_eop()
 
-    Parameters: 
+    Parameters:
         out_days -> [int, default = 7] Update cycle of the EOP file
         dir_to   -> [str, default = None] Directory for storing EOP file
-    
-    Outputs: 
+
+    Outputs:
         eop_file -> [str] Path of the EOP file
     """
     if dir_to is None:
         home = str(Path.home())
         dir_to = home + '/src/eop-data/'
-    
+
     file = 'finals.all.iau2000.txt'
     dir_file = dir_to + file
 
     url = 'https://datacenter.iers.org/data/latestVersion/finals.all.iau2000.txt'
 
-    if not path.exists(dir_to): makedirs(dir_to)
+    if not path.exists(dir_to):
+        makedirs(dir_to)
 
     if path.exists(dir_file):
         # First check if the file needs updating
@@ -39,15 +39,17 @@ def download_eop(out_days=7,dir_to=None):
             remove(dir_file)
             desc = "Updating EOP '{:s}' from IERS".format(file)
         else:
-            print("EOP '{0:s}' in {1:s} is already the latest.".format(file,dir_to)) 
+            print("EOP '{0:s}' in {1:s} is already the latest.".format(
+                file, dir_to))
             return dir_file
     else:
         desc = "Downloading the latest EOP '{:s}' from IERS".format(file)
-        
-    if tqdm_request_http(url,dir_to,file,desc) is None:
-        print('SLRfield was unable to import Earth Orientation Parameters (EOP) data. ' \
-            + 'It is recommended to try again or to manually download this data (finals.all.iau2000.txt)'\
-            + f' and place it in {dir_to}.')
+
+    if tqdm_request_http(url, dir_to, file, desc) is None:
+        print('SLRfield was unable to import Earth Orientation Parameters '
+              + '(EOP) data. It is recommended to try again or to manually'
+              + 'download this data (finals.all.iau2000.txt) and place it '
+              + f'in {dir_to}.')
         raise ImportError('Unable to download EOP data')
 
     return dir_file

--- a/slrfield/utils/data_prepare.py
+++ b/slrfield/utils/data_prepare.py
@@ -9,6 +9,6 @@ def time_load():
     eop_file = download_eop()
  
     # for astropy
-    if eop_file is not None:
+    if eop_file is None:
         iers_a = iers_astropy.IERS_A.open(eop_file)
         iers_astropy.earth_orientation_table.set(iers_a)

--- a/slrfield/utils/data_prepare.py
+++ b/slrfield/utils/data_prepare.py
@@ -1,11 +1,14 @@
 from astropy.utils import iers as iers_astropy
+from requests import ConnectionError, HTTPError, Timeout
+
 from .data_download import download_eop
 
-def time_load():
 
+def time_load():
     # load the EOP file
     eop_file = download_eop()
-
+ 
     # for astropy
-    iers_a = iers_astropy.IERS_A.open(eop_file)
-    eop_table = iers_astropy.earth_orientation_table.set(iers_a)
+    if eop_file is not None:
+        iers_a = iers_astropy.IERS_A.open(eop_file)
+        iers_astropy.earth_orientation_table.set(iers_a)

--- a/slrfield/utils/data_prepare.py
+++ b/slrfield/utils/data_prepare.py
@@ -1,5 +1,4 @@
 from astropy.utils import iers as iers_astropy
-from requests import ConnectionError, HTTPError, Timeout
 
 from .data_download import download_eop
 
@@ -7,7 +6,7 @@ from .data_download import download_eop
 def time_load():
     # load the EOP file
     eop_file = download_eop()
- 
+
     # for astropy
     if eop_file is None:
         iers_a = iers_astropy.IERS_A.open(eop_file)

--- a/slrfield/utils/try_download.py
+++ b/slrfield/utils/try_download.py
@@ -3,10 +3,12 @@ from tqdm import tqdm
 from colorama import Fore
 from time import sleep
 import requests
+from ftplib import all_errors
 
-def tqdm_ftp(ftp,dir_to,file,desc):
+
+def tqdm_ftp(ftp, dir_to, file, desc):
     """
-    Try to download files from remote server by ftp with a colored progress bar.
+    Try to download files from remote server by ftp with a colored progress bar
     """
     dir_file = dir_to + file
     total_size = int(ftp.size(file))
@@ -14,24 +16,28 @@ def tqdm_ftp(ftp,dir_to,file,desc):
 
     for idownload in range(5):
         try:
-            local_file =  open(dir_file, 'wb')
+            local_file = open(dir_file, 'wb')
             pos = local_file.tell()
-            pbar = tqdm(desc = desc,total=total_size,unit='B',unit_scale=True,position=0,initial=pos,bar_format=bar_format)
+            pbar = tqdm(desc=desc, total=total_size, unit='B', unit_scale=True,
+                        position=0, initial=pos, bar_format=bar_format)
+
             def progressbar(chunk):
                 local_file.write(chunk)
                 pbar.update(len(chunk))
-            res = ftp.retrbinary('RETR ' + file, progressbar) # RETR is an FTP command
-            break       
-        except:
+            # RETR is an FTP command
+            ftp.retrbinary('RETR ' + file, progressbar)
+            break
+        except all_errors:
             sleep(2)
             if idownload == 4:
                 remove(dir_file)
                 print('No response, skip {:s}'.format(file))
         finally:
             pbar.close()
-            local_file.close()       
+            local_file.close()
 
-def tqdm_request_http(url,dir_cpf_to,cpf_file,desc):
+
+def tqdm_request_http(url, dir_cpf_to, cpf_file, desc):
     """
     Try to download CPF or OEP files from url with a colored progress bar.
     """
@@ -42,26 +48,31 @@ def tqdm_request_http(url,dir_cpf_to,cpf_file,desc):
         try:
             local_file = open(dir_cpf_to + cpf_file, 'wb')
             pos = local_file.tell()
-            res = requests.get(url,stream=True,timeout=200,headers={'Accept-Encoding': None,'Range': f'bytes={pos}-'})
+            res = requests.get(url, stream=True, timeout=200, headers={
+                               'Accept-Encoding': None,
+                               'Range': f'bytes={pos}-'})
             res.raise_for_status()
             total_size = int(res.headers.get('Content-Length'))
-            pbar = tqdm(desc = desc,total=total_size,unit='B',unit_scale=True,bar_format = bar_format,position=0,initial=pos)
+            pbar = tqdm(desc=desc, total=total_size, unit='B', unit_scale=True,
+                        bar_format=bar_format, position=0, initial=pos)
             for chunk in res.iter_content(block_size):
-                local_file.write(chunk)  
-                pbar.update(len(chunk))   
-            pbar.close()   
-            res.close()  
+                local_file.write(chunk)
+                pbar.update(len(chunk))
+            pbar.close()
+            res.close()
             break
-        except (requests.HTTPError, requests.ConnectionError, requests.Timeout) as e: 
+        except (requests.HTTPError,
+                requests.ConnectionError,
+                requests.Timeout) as e:
             sleep(3)
             if idownload == 4:
                 remove(dir_cpf_to + cpf_file)
-                print('No response, skip {:s}'.format(cpf_file)) 
+                print(f'No response {str(e)}, skip {cpf_file}')
                 missing_flag = True
-        finally:    
+        finally:
             local_file.close()
 
-    if missing_flag: 
-        return cpf_file 
+    if missing_flag:
+        return cpf_file
     else:
-        return None      
+        return None

--- a/slrfield/utils/try_download.py
+++ b/slrfield/utils/try_download.py
@@ -33,7 +33,7 @@ def tqdm_ftp(ftp,dir_to,file,desc):
 
 def tqdm_request_http(url,dir_cpf_to,cpf_file,desc):
     """
-    Try to download cpf files from url with a colored progress bar.
+    Try to download CPF or OEP files from url with a colored progress bar.
     """
     block_size = 1024*10
     missing_flag = False
@@ -62,6 +62,6 @@ def tqdm_request_http(url,dir_cpf_to,cpf_file,desc):
             local_file.close()
 
     if missing_flag: 
-        return None 
+        return cpf_file 
     else:
-        return cpf_file      
+        return None      


### PR DESCRIPTION
Hi,
First of all, thanks for the package, I have found the propagator to be very useful.
However, as also stated in issue #5, the downloaders are potentially powerful but broken at the moment. This PR fixes these issues to get in line with changes due to mainly CCDIS switching to CPF v2.
The changes are as follows:

1. The dependency `requests` was missing and has been added. It has been added with a version wildcard though, but it should be fine with at least all versions from the last couple of years.
2. The EOP data provided by the IERS is not available through FTP anymore. Fortunately, they still provide it as an HTTPS download, so I have updated the code. Note however that on my system, `astropy` seems to download the EOP automatically anyway when it is not set, so the downloader may be superfluous? 
3. For the downloads from both CCDIS and EDC, it will try to download CPFv1 files if the specified date (if any) is from before the 1st October 2021 and CPFv2 files if it is after that date. This is because these organisations formally adopted v2 on this with various differences. Most notably, the 'current' datafiles are only available in CPFv2.
4. The web scraper for CCDIS has been modified to remove the checksum files from the search tree in a more direct fashion, as it varies a lot whether these files are available or not. This makes the downloads from CCDIS more robust.
5. Various small fixes in the code and its formatting. Most files are now fully pep8 compliant, but I haven't looked at all files (yet).
